### PR TITLE
Fix typo in XMR TxID validation

### DIFF
--- a/js/validations.js
+++ b/js/validations.js
@@ -174,7 +174,7 @@ function isValidInfo(infoType, infoDetail) {
 				isValidLTCTxID(infoDetail) ||
 				isValidTRONTxID(infoDetail) ||
 				isValidSOLTxID(infoDetail) ||
-				isValidXMRTXID(infoDetail) ||
+                                isValidXMRTxID(infoDetail) ||
 				isValidKaspaTxID(infoDetail) ||
 				isValidSuiTxID(infoDetail) ||
 				isValidAptosTxID(infoDetail) ||


### PR DESCRIPTION
## Summary
- fix function name typo in `isValidInfo` for XMR TxID

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683ffb7baaf083299c20c6a6422a2cca